### PR TITLE
Fix sending attachments as multipart messages 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@orangebeard-io/javascript-client",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "description": "Orangebeard client for JavaScript",
     "main": "dist/client/index.js",
     "scripts": {
@@ -31,10 +31,9 @@
     },
     "homepage": "https://github.com/orangebeard-io/javascript-client#readme",
     "dependencies": {
-        "@types/node": "^20.7.0",
-        "axios": "^1.6.5",
-        "axios-retry": "^4.0.0",
-        "form-data": "^4.0.0"
+        "@types/node": "^20.14.2",
+        "axios": "^1.7.2",
+        "axios-retry": "^4.4.0"
     },
     "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^6.19.0",

--- a/src/client/OrangebeardAsyncV3Client.ts
+++ b/src/client/OrangebeardAsyncV3Client.ts
@@ -247,7 +247,7 @@ export default class OrangebeardAsyncV3Client {
       parent.then((actualLogUUID) => {
         const realAttachment = {
           ...attachment,
-          metadata: {
+          metaData: {
             ...attachment.metaData,
             testRunUUID: this.uuidMap[attachment.metaData.testRunUUID],
             testUUID: this.uuidMap[attachment.metaData.testUUID],

--- a/src/client/OrangebeardClient.ts
+++ b/src/client/OrangebeardClient.ts
@@ -1,7 +1,6 @@
 import axios, { AxiosError, AxiosInstance, AxiosResponse } from 'axios';
 import axiosRetry from 'axios-retry';
 import { UUID } from 'crypto';
-import FormData from 'form-data';
 
 import { StartTestRun } from './models/StartTestRun';
 import { FinishTestRun } from './models/FinishTestRun';
@@ -215,17 +214,14 @@ export default class OrangebeardClient {
   public async sendAttachment(attachment: Attachment): Promise<UUID | null> {
     try {
       const formData = new FormData();
-      const fileBlob = new Blob([attachment.file.content], { type: attachment.file.contentType });
-      const metaBlob = new Blob([JSON.stringify(attachment.metaData)], {
-        type: 'application/json',
-      });
 
-      formData.append('json', metaBlob);
+      const fileBlob = new Blob([attachment.file.content], { type: attachment.file.contentType });
+
+      formData.append('json', JSON.stringify(attachment.metaData));
       formData.append('attachment', fileBlob, attachment.file.name);
 
       const headers = {
         Authorization: `Bearer ${this.accessToken}`,
-        'Content-Type': 'multipart/form-data',
       };
 
       const response: AxiosResponse<UUID> = await this.httpClient.post(


### PR DESCRIPTION
- Fix sending attachments as multipart messages correctly;
- Use correct metaData object;
- Dependency updates;